### PR TITLE
Fix MFA and socialLoginConfig settings

### DIFF
--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -76,6 +76,9 @@ export class Web3AuthConnector extends Connector {
       adapterSettings: {
         ...config.options,
       },
+      loginSettings: {
+        ...config.options.socialLoginConfig
+      },
       chainConfig: finalChainConfig,
     });
 


### PR DESCRIPTION

## Description

The `socialLoginConfig` does not have any effect when the setting is specified. So with a setting `mfaLevel: none` the UI still asks to set up MFA after 3 logins which is a default behaviour. 

```typescript
  const { connect, status } = useConnect({
    connector: new Web3AuthConnector({
      options: {
        uiConfig: {
          theme: 'dark',
        },
        socialLoginConfig: {
          mfaLevel: 'none',  // <-- this did not apply
        },
        // ...
      }
    })
  })
 ```

## How Has This Been Tested?
Built the code and cleaned node_modules cache. Retried over 3 times and MFA setting is working as expected after the change.




