### PR TITLE
[Bug Fix] Emit proper change on switchChain

### DIFF
--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -101,7 +101,7 @@ export class Web3AuthConnector extends Connector<SafeEventEmitterProvider, Optio
 
   async getAccount(): Promise<Address> {
     const provider = await this.getProvider();
-    const accounts = await provider.request<unknown, string[]>({
+    const accounts = await provider.request<string[]>({
       method: "eth_accounts",
     });
     return getAddress(accounts[0]);
@@ -139,7 +139,7 @@ export class Web3AuthConnector extends Connector<SafeEventEmitterProvider, Optio
 
   async getChainId(): Promise<number> {
     await this.getProvider();
-    const chainId = await this.provider.request<unknown, string>({ method: "eth_chainId" });
+    const chainId = await this.provider.request<string>({ method: "eth_chainId" });
     log.info("chainId", chainId);
     return normalizeChainId(chainId);
   }
@@ -162,6 +162,10 @@ export class Web3AuthConnector extends Connector<SafeEventEmitterProvider, Optio
       log.info("Chain Added: ", chain.name);
       await this.web3AuthInstance.switchChain({ chainId: `0x${chain.id.toString(16)}` });
       log.info("Chain Switched to ", chain.name);
+      // Emit the change to wagmi
+      this.emit('change', {
+        chain
+      })
       return chain;
     } catch (error: unknown) {
       log.error("Error: Cannot change chain", error);


### PR DESCRIPTION
### Setup: 
1. react
2. wagmi 
3. plug and play
4. no plugins
5. openlogin adapter
6. all latest versions: ~7.2.x

###Problem
[based on the chain switching issues see here](https://github.com/Web3Auth/web3auth-wagmi-connector/issues?q=is%3Aissue+is%3Aopen+chain) and my own issues with the matter.

There was no `emit` call happening to update the `SafeEventEmitter` for `wagmi` to update on their side

## EDIT

After further investigation I've come to realise there are some bugs related to the "provider" vs "adapter" side of things. Looking at the `connect` function of the `Web3AuthConnector`, [specifically here](https://github.com/Web3Auth/web3auth-wagmi-connector/blob/9a1c5b92d980ea3e98377fd69f0745ded8b4af08/src/lib/connector.ts#L55), we can see that the connector is subscribed to any provider chain changes (as well as account, above), via 

```ts
this.provider.on("chainChanged", this.onChainChanged);
``` 
(as most wagmi connectors do) but the issue is that the provider in the `Web3AuthConnector` is `null`. You need to grab the adapter provider instead. See below for more info.

--
`L127` [seen here](https://github.com/Web3Auth/web3auth-wagmi-connector/blob/9a1c5b92d980ea3e98377fd69f0745ded8b4af08/src/lib/connector.ts#L127C5-L128C1) sets the `provider` as the `web3authInstance.provider`:
```ts
  async getProvider() {
    if (this.provider) {
      return this.provider;
    }
    // ... other code
   
    // here you set the provider to the web3AuthInstance provider
    this.provider = this.web3AuthInstance.provider;
    return this.provider;
  }
```

Next we need to take a look at the `web3AuthInstance` code, which is inside `@web3auth-web/packages/no-modal/src/noModal.ts` 

[On this line we can see the setting of the provider](https://github.com/Web3Auth/web3auth-web/blob/e40fd51b4f54738b4038f6f7370151500306d06f/packages/no-modal/src/noModal.ts#L117) which shows it's EITHER the `CommonJRPCProvider` OR it's `null`

```ts
get provider(): IProvider | null {
    if (this.status !== ADAPTER_STATUS.NOT_READY && this.commonJRPCProvider) {
      return this.commonJRPCProvider;
    }
    return null;
  }
```

So the provider inside the `Web3AuthConnector` is `null` or it's the JRPC provider. This shouldn't be a problem except that switching chains doesn't trigger the `CommonJRPC` connector for switching chains, instead it is calling the connected wallet adapter, [seen here](https://github.com/Web3Auth/web3auth-web/blob/e40fd51b4f54738b4038f6f7370151500306d06f/packages/no-modal/src/noModal.ts#L202):

```ts
public async switchChain(params: { chainId: string }): Promise<void> {
    if (this.status === ADAPTER_STATUS.CONNECTED && this.connectedAdapterName)
      return this.walletAdapters[this.connectedAdapterName].switchChain(params);

    if (this.commonJRPCProvider) {
      return this.commonJRPCProvider.switchChain(params);
    }
    throw WalletInitializationError.notReady(`No wallet is ready`);
  }
```

## Solution

I think it's probably enough to just listen for both the provider AND the adapter (should it exist) emitted values. See PR changes.