### PR TITLE
Implement Dynamic ID and Name for Web3Auth Connectors Based on Login Providers

### DIFF
--- a/demos/wagmi-no-modal/package-lock.json
+++ b/demos/wagmi-no-modal/package-lock.json
@@ -38,7 +38,7 @@
     },
     "../..": {
       "name": "@web3auth/web3auth-wagmi-connector",
-      "version": "5.0.1",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/cli": "^2.27.1",

--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -18,8 +18,8 @@ export function Web3AuthConnector(parameters: Web3AuthConnectorParams) {
   const { web3AuthInstance, loginParams, modalConfig } = parameters;
 
   return createConnector<Provider>((config) => ({
-    id: "web3auth",
-    name: "Web3Auth",
+    id: loginParams?.loginProvider || "web3auth",
+    name: loginParams?.loginProvider ? loginParams.loginProvider.charAt(0).toUpperCase() + loginParams.loginProvider.slice(1) : "Web3Auth",
     type: "Web3Auth",
     async connect({ chainId } = {}) {
       try {
@@ -71,7 +71,9 @@ export function Web3AuthConnector(parameters: Web3AuthConnectorParams) {
     },
     async getChainId() {
       const provider = await this.getProvider();
-      const chainId = await provider.request<unknown, number>({ method: "eth_chainId" });
+      const chainId = await provider.request<unknown, number>({
+        method: "eth_chainId",
+      });
       return normalizeChainId(chainId);
     },
     async getProvider(): Promise<Provider> {
@@ -121,7 +123,9 @@ export function Web3AuthConnector(parameters: Web3AuthConnectorParams) {
             : "https://images.toruswallet.io/eth.svg",
         });
         log.info("Chain Added: ", chain.name);
-        await web3AuthInstance.switchChain({ chainId: `0x${chain.id.toString(16)}` });
+        await web3AuthInstance.switchChain({
+          chainId: `0x${chain.id.toString(16)}`,
+        });
         log.info("Chain Switched to ", chain.name);
         config.emitter.emit("change", {
           chainId,


### PR DESCRIPTION
This update introduces the ability to dynamically assign IDs and display names to Web3Auth connectors based on the specified login provider. This enhancement simplifies the management of multiple connectors in a single application, providing clearer identification and better usability in client-side implementations.

**Key Changes:**
- The connector’s `id` and `name` are now set based on the `loginProvider` parameter, falling back to "web3auth" if not specified.
- Supports a range of login providers, enhancing the flexibility of the Web3Auth setup process.

**Benefits:**
- **Improved Traceability:** Each connector can be easily traced in the frontend, beneficial for debugging and user interface logic.
- **Enhanced Customization:** Allows developers to provide a more personalized experience tailored to the login method used.
- **Simplified Configuration:** Reduces the complexity of handling multiple connectors by using identifiable names and IDs.

**Example Usage:**

Before:
```javascript
const connector = Web3AuthConnector({ loginProvider: 'google' });
// Previously, this would default to generic IDs and names.
```

After:
```javascript
const connector = Web3AuthConnector({ loginProvider: 'google' });
// Now, the connector ID and name will be "google" and "Google", respectively.
```

This update does not introduce breaking changes to existing implementations but extends the functionality to support a more structured and maintainable approach when dealing with various Web3Auth connectors.