### PR TITLE
Fixes #147 - error in `blockExplorers.default.url` type: `array` to `string`

### DIFF
--- a/src/lib/connector.ts
+++ b/src/lib/connector.ts
@@ -112,7 +112,7 @@ export function Web3AuthConnector(parameters: Web3AuthConnectorParams) {
           chainId: `0x${chain.id.toString(16)}`,
           rpcTarget: chain.rpcUrls.default.http[0],
           displayName: chain.name,
-          blockExplorerUrl: chain.blockExplorers?.default.url[0] || "",
+          blockExplorerUrl: chain.blockExplorers?.default.url || "",
           ticker: chain.nativeCurrency?.symbol || "ETH",
           tickerName: chain.nativeCurrency?.name || "Ethereum",
           decimals: chain.nativeCurrency?.decimals || 18,


### PR DESCRIPTION
Closes #147 

## Motivation and Context
Broken chain switching as derived chain was parsed incorrectly with passed in types. See #147 

## Screenshots
Error in console BEFORE change:
<img width="822" alt="image" src="https://github.com/user-attachments/assets/bf81263f-3341-4555-b0c4-c946d31c499d">
<img width="842" alt="image" src="https://github.com/user-attachments/assets/4f71234e-e46b-4111-8855-f066656cde6d">

`blockExplorersUrl: "h"` is because of the previous wrong code: 
```ts
chain.blockExplorers?.default.url[0]
```
when `url` => e.g `"https://sepolia-infura.io/api/v2" it would grab first string character at index `0` equalling `"h"`
